### PR TITLE
Fix parliament figures

### DIFF
--- a/demokratikollen/www/app/static/js/parliament.js
+++ b/demokratikollen/www/app/static/js/parliament.js
@@ -117,19 +117,20 @@ P = {
 
     switch(P.page) {
     case 'parliament':
-        P.FetchParliamentData(date.toLocaleDateString(),'');
+        P.FetchParliamentData(date,'');
         break;
     case 'gender':
-        P.FetchGenderData(date.toLocaleDateString(),'');
+        P.FetchGenderData(date,'');
         break;
     }
   },
   FetchGenderData: function(date, party) {
 
       date = typeof date !== 'undefined' ? date : '';
+      dateString = date.toISOString().slice(0,10)
       party = typeof party !== 'undefined' ? party : '';
 
-      d3.json("/data/gender.json?party=" + party + "&date=" + date, function(error, root) {
+      d3.json("/data/gender.json?party=" + party + "&date=" + dateString, function(error, root) {
 
         var data = {'name': 'root', 'children': root.data};
 
@@ -145,8 +146,9 @@ P = {
   FetchParliamentData: function(date) {
 
       date = typeof date !== 'undefined' ? date : '';
+      dateString = date.toISOString().slice(0,10)
 
-      d3.json("/data/parliament.json?date=" + date, function(error, data) {
+      d3.json("/data/parliament.json?date=" + dateString, function(error, data) {
         P.GenerateChairsPositions(data);
         P.DrawMemberNodes(data.data);
       });

--- a/demokratikollen/www/app/views/data.py
+++ b/demokratikollen/www/app/views/data.py
@@ -26,7 +26,7 @@ def gender_json():
         try:
             date = datetime.datetime.strptime(str_date, '%Y-%m-%d').date()
         except ValueError:
-            return "Felaktig datumparameter. Formatet är: ÅÅ-MM-DD", 400
+            return "Felaktig datumparameter. Formatet är: ÅÅÅÅ-MM-DD", 400
 
     json = data.gender_json(date=date,party=party)
 


### PR DESCRIPTION
The `date` argument sent in the json data request is formatted using `Date.toLocaleDateString()` and will consequently only work if your locale happens to return something in the right format. (It did not on my development  machine.)

I propose that we make it up to the data fetching function to format the date correctly.
